### PR TITLE
Added exit sleep mode event support

### DIFF
--- a/Nextion.cpp
+++ b/Nextion.cpp
@@ -70,6 +70,7 @@ void Nextion::poll()
         }
       }
     }
+#ifdef NEX_SS	
 	else if(c == NEX_RET_EVENT_SLEEP_POSITION_HEAD)
 	{
 	 delay(10);	
@@ -81,6 +82,7 @@ void Nextion::poll()
       else item = item->next;
      }
 	}
+#endif
   }
 }
 

--- a/NextionTypes.h
+++ b/NextionTypes.h
@@ -3,15 +3,16 @@
 #ifndef __NEONEXTION_NEXTIONTYPES
 #define __NEONEXTION_NEXTIONTYPES
 
+
+#define NEX_SS true		//The code supports Screen Saver (using sleep) mode?
+#define NEX_SS_COMP 1	//Touching that component ID will activare event to exit Screen Saver mode (event attached will be called)
+#define NEX_SS_PAGE 0	//The page in which component is
+
+
 /*!
  * \enum NextionValue
  * \brief Values used in messages.
  */
- 
- #define NEX_SS_PAGE 0
- #define NEX_SS_COMP 1
-  
- 
 enum NextionValue
 {
   NEX_RET_CMD_FINISHED = (0x01),


### PR DESCRIPTION
Sometimes can be useful put the display in sleep mode. Setting command "thup=1", the display is waked up by a touch event.
The touch event is sent to microcontroller with X and Y coordinates, but the original poll() code does not manage that event.

I added the capability of managing that event in a defined page and component ID, so a callback function can be called.

This because microcontroller needs to know (or it should know!) if the display is in sleep mode or not.

There are 3 new #define in NextionTypes.h:

#define NEX_SS true/false    : code supports Screen Saver (using sleep) mode?
#define NEX_SS_COMP XX  : touching component ID XX will activare event to exit Screen Saver mode (event attached will be called)
#define NEX_SS_PAGE YY    : the page YY in which component is

Note: if no callback defined, the display exits sleep mode but, obviously, nothing is called.

The most common use is to create an entire screen touch area and attach a callback. Whe